### PR TITLE
Import todoist-shortcuts as submodule instead of download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+Todoist-*
+todoist.js

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "todoist-shortcuts"]
+	path = todoist-shortcuts
+	url = https://github.com/mgsloan/todoist-shortcuts

--- a/README.md
+++ b/README.md
@@ -19,10 +19,7 @@ Unfortunately, `nativefier` has an issue with [injecting multiple JavaScript fil
 First, you install the dependencies:
 `npm install`
 
-Next, we need to download `todoist-shortcuts`:
-`npm run downloadTodoistShortcuts`
-
-Finally, we build the application:
+Then, we build the application:
 `npm run buildApplication`
 
 ## Workflow using Both Applications

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-cat ./counter.js > todoist.js; cat ./todoist-shortcuts-28/src/todoist-shortcuts.js >> todoist.js
+git submodule update --init --recursive
+cat ./counter.js > todoist.js; cat ./todoist-shortcuts/src/todoist-shortcuts.js >> todoist.js
 nativefier 'https://todoist.com/' --name 'Todoist' --icon ./todoist-icon.png --inject ./todoist.js --counter --bounce --single-instance --overwrite

--- a/clean.sh
+++ b/clean.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
-rm -f todoist-shortcuts-28.tar.gz
-rm -rf todoist-shortcuts-28
 rm -f todoist.js
 rm -rf Todoist-*

--- a/download-todoist-shortcuts.sh
+++ b/download-todoist-shortcuts.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-curl -LJO https://github.com/mgsloan/todoist-shortcuts/archive/v28.tar.gz
-tar -xzf todoist-shortcuts-28.tar.gz

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "nativefier": "^7.6.0"
   },
   "scripts": {
-    "downloadTodoistShortcuts": "./download-todoist-shortcuts.sh",
     "buildApplication": "./build.sh",
     "clean": "./clean.sh"
   }


### PR DESCRIPTION
Hi.

A badge count is added to nativefier and todoist-shortcuts, which is very convenient. Thank you.

Every time the todoist-shortcuts version was updated, I edited the code and rebuilt it. But I think it would be better to import todoist-shortcuts as submodule and update the submodule version instead of editing the code.

In this case, there is no need to download, and if you upgrade the submodule version and commit it, there is no need for others to edit the code or update submodule, expect for git pull.

Please merge if you like.